### PR TITLE
fix: correct invalid azure/arm-deploy SHA

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,7 +61,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Deploy Bicep template
-        uses: azure/arm-deploy@e792c9a34eb6a018b445eff5f1a6394f0c6e1e2d # v2.0.0
+        uses: azure/arm-deploy@a1361c2c2cd398621955b16ca32e01c65ea340f5 # v2
         with:
           scope: subscription
           region: ${{ env.AZURE_LOCATION }}


### PR DESCRIPTION
## Summary
- Fixes deploy-infra job failure caused by invalid `azure/arm-deploy` SHA `e792c9a34eb6a018b445eff5f1a6394f0c6e1e2d` (doesn't exist in the repo)
- Updated to correct SHA `a1361c2c2cd398621955b16ca32e01c65ea340f5` (v2 tag)

## Test plan
- [ ] Merge triggers CI/CD pipeline
- [ ] `deploy-infra` job passes (Bicep deployment succeeds)
- [ ] `deploy-backend` and `deploy-frontend` jobs run in parallel and pass
- [ ] SWA `swa-options-pipeline-*` provisioned; URL available from Bicep output

🤖 Generated with [Claude Code](https://claude.com/claude-code)