### PR TITLE
fix: extract AcrPull role assignment into module (BCP120/BCP139)

### DIFF
--- a/infra/bicep/main.bicep
+++ b/infra/bicep/main.bicep
@@ -81,22 +81,16 @@ module acr 'modules/acr.bicep' = {
 
 // ---------------------------------------------------------------------------
 // AcrPull role assignment – allows AKS kubelet identity to pull images
+// Deployed as a module (resource-group scope) to satisfy BCP139 and BCP120
 // ---------------------------------------------------------------------------
 
-var acrPullRoleDefinitionId = '7f951dda-4ed3-4680-a7ca-43fe172d538d'
-
-resource acrPullRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(acr.outputs.acrId, aks.outputs.kubeletIdentityObjectId, acrPullRoleDefinitionId)
-  scope: resourceGroup(resourceGroupName)
-  properties: {
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', acrPullRoleDefinitionId)
-    principalId: aks.outputs.kubeletIdentityObjectId
-    principalType: 'ServicePrincipal'
+module acrPullRoleAssignment 'modules/roleassignment.bicep' = {
+  name: 'roleassignment-deployment'
+  scope: rg
+  params: {
+    acrId: acr.outputs.acrId
+    kubeletPrincipalId: aks.outputs.kubeletIdentityObjectId
   }
-  dependsOn: [
-    acr
-    aks
-  ]
 }
 
 // ---------------------------------------------------------------------------

--- a/infra/bicep/modules/roleassignment.bicep
+++ b/infra/bicep/modules/roleassignment.bicep
@@ -1,0 +1,12 @@
+param acrId string
+param kubeletPrincipalId string
+param acrPullRoleDefinitionId string = '7f951dda-4ed3-4680-a7ca-43fe172d538d'
+
+resource acrPullRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(acrId, kubeletPrincipalId, acrPullRoleDefinitionId)
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', acrPullRoleDefinitionId)
+    principalId: kubeletPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}


### PR DESCRIPTION
## Summary
- Resolves BCP120: `guid()` in role assignment `name` used runtime module outputs — not allowed at subscription scope
- Resolves BCP139: inline `Microsoft.Authorization/roleAssignments` with `scope: resourceGroup(...)` can't be declared at subscription scope — must be a module
- Removes unnecessary `dependsOn` warnings (ARM infers ordering from parameter references)

## Changes
- **New**: `infra/bicep/modules/roleassignment.bicep` — resource-group-scoped module for the AcrPull role assignment
- **Modified**: `infra/bicep/main.bicep` — replaced inline `resource` block with `module acrPullRoleAssignment`

## Test plan
- [ ] Bicep validation passes: `az bicep build --file infra/bicep/main.bicep`
- [ ] Deploy Infrastructure job succeeds in CI
- [ ] AKS can pull images from ACR after deploy

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)