### PR TITLE
fix: backend Dockerfile — copy into package subdir to resolve imports

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,11 +13,11 @@ FROM python:3.11-slim
 WORKDIR /app
 
 COPY --from=builder /install /usr/local
-COPY . .
+COPY . ./backend/
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
 EXPOSE 8000
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Problem
Backend pods in CrashLoopBackOff with `ModuleNotFoundError: No module named 'backend'`.

`Dockerfile` used `COPY . .` which places `backend/` contents directly into `/app`, so `/app/main.py` exists but `from backend.api...` imports fail — there's no `backend/` subdirectory on the Python path.

## Fix
- `COPY . ./backend/` — files land at `/app/backend/main.py`, `/app/backend/api/`, etc.
- CMD updated to `uvicorn backend.main:app` — resolves from `/app` workdir

## Test plan
- [ ] Deploy Backend job succeeds (pods Running, not CrashLoopBackOff)
- [ ] `kubectl get pods -n production -l app=options-backend` shows Ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)