### PR TITLE
fix: backend startup errors — stray filepath and circular import

### DIFF
--- a/backend/api/routers/__init__.py
+++ b/backend/api/routers/__init__.py
@@ -1,1 +1,0 @@
-from backend.api.routers import trades

--- a/backend/services/tradability_service.py
+++ b/backend/services/tradability_service.py
@@ -1,5 +1,3 @@
-backend/services/tradability_service.py
-
 from typing import Any, Optional
 import math
 


### PR DESCRIPTION
## Problem
Backend pods crash immediately after the Dockerfile fix landed:

1. `tradability_service.py` line 1 was a bare filepath string (`backend/services/tradability_service.py`) — Python evaluated it as an expression causing `NameError: name 'backend' is not defined`
2. `api/routers/__init__.py` contained `from backend.api.routers import trades` — a self-referential circular import that crashed uvicorn on startup

## Fix
- Removed stray line 1 from `tradability_service.py`
- Emptied `routers/__init__.py` (the import was unnecessary — routes are included directly in `main.py`)

## Test plan
- [ ] Backend pods reach Running state (no CrashLoopBackOff)
- [ ] `GET /health` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)