### PR TITLE
fix: --force-conflicts on kubectl apply for SSA conflict

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -206,7 +206,7 @@ jobs:
         id: apply
         env:
           NAMESPACE: ${{ env.K8S_NAMESPACE }}
-        run: kubectl apply -f infra/k8s/ --server-side --namespace="$NAMESPACE"
+        run: kubectl apply -f infra/k8s/ --server-side --force-conflicts --namespace="$NAMESPACE"
 
       - name: Wait for rollout to complete
         id: rollout_wait


### PR DESCRIPTION
Added --force-conflicts to kubectl apply in deploy.yml to resolve server-side apply field manager conflict left by previous rollback.