### PR TITLE
feat: enable HTTPS on backend ingress via cert-manager + Let's Encrypt

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -189,11 +189,13 @@ jobs:
           NAMESPACE: ${{ env.K8S_NAMESPACE }}
           AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}
           KEY_VAULT_URL: ${{ secrets.KEY_VAULT_URL }}
+          ALLOWED_ORIGINS: ${{ vars.ALLOWED_ORIGINS }}
         run: |
           set -euo pipefail
           kubectl create secret generic options-backend-secrets \
             --from-literal=azure-storage-connection-string="${AZURE_STORAGE_CONNECTION_STRING}" \
             --from-literal=key-vault-url="${KEY_VAULT_URL}" \
+            --from-literal=allowed-origins="${ALLOWED_ORIGINS}" \
             --namespace="${NAMESPACE}" \
             --dry-run=client -o yaml | kubectl apply -f -
 
@@ -250,14 +252,10 @@ jobs:
           INGRESS_NAME: ${{ vars.BACKEND_INGRESS_NAME || 'backend' }}
         run: |
           set -euo pipefail
-          for i in $(seq 1 12); do
-            BACKEND_URL=$(kubectl get ingress "${INGRESS_NAME}" -n "${{ env.K8S_NAMESPACE }}" -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null || true)
-            [ -n "$BACKEND_URL" ] && break
-            echo "Waiting for ingress hostname... attempt $i/12"
-            sleep 10
-          done
+          # Use the first host from the ingress spec (nip.io hostname) for TLS smoke test.
+          BACKEND_URL=$(kubectl get ingress "${INGRESS_NAME}" -n "${{ env.K8S_NAMESPACE }}" -o jsonpath='{.spec.rules[0].host}' 2>/dev/null || true)
           if [ -z "$BACKEND_URL" ]; then
-            echo "ERROR: Ingress hostname not assigned after 2 minutes" && exit 1
+            echo "ERROR: No ingress host found on '${INGRESS_NAME}'" && exit 1
           fi
           # Retry loop to wait for TLS certificate provisioning before running the smoke test.
           # --insecure is intentionally avoided; instead we poll until the cert is valid.

--- a/frontend/vue-app/.env.example
+++ b/frontend/vue-app/.env.example
@@ -1,1 +1,1 @@
-VITE_API_BASE_URL=http://localhost:8000
+VITE_API_BASE_URL=https://backend.20.106.111.251.nip.io

--- a/frontend/vue-app/src/App.vue
+++ b/frontend/vue-app/src/App.vue
@@ -59,10 +59,10 @@ const {
   vix,
   options,
   bestTrade,
-  polling,
-  calculating,
-  pollOptions,
-  calculateTrades,
+  isPolling: polling,
+  isCalculating: calculating,
+  fetchMarketData: pollOptions,
+  fetchBestTrade: calculateTrades,
 } = useMarketData()
 
 const loading = ref(false)

--- a/frontend/vue-app/src/api/endpoints.js
+++ b/frontend/vue-app/src/api/endpoints.js
@@ -1,4 +1,3 @@
-frontend/vue-app/src/api/endpoints.js
 import apiClient from './client.js'
 
 export async function pollOptions({ delta, expiry }) {

--- a/infra/k8s/cluster-issuer.yaml
+++ b/infra/k8s/cluster-issuer.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    # Replace with a real email address to receive Let's Encrypt expiry notices.
+    email: admin@example.com
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    solvers:
+      - http01:
+          ingress:
+            class: nginx

--- a/infra/k8s/deployment.yaml
+++ b/infra/k8s/deployment.yaml
@@ -32,6 +32,11 @@ spec:
                 secretKeyRef:
                   name: options-backend-secrets
                   key: key-vault-url
+            - name: ALLOWED_ORIGINS
+              valueFrom:
+                secretKeyRef:
+                  name: options-backend-secrets
+                  key: allowed-origins
           livenessProbe:
             httpGet:
               path: /health

--- a/infra/k8s/ingress.yaml
+++ b/infra/k8s/ingress.yaml
@@ -7,9 +7,15 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    cert-manager.io/cluster-issuer: letsencrypt-prod
 spec:
+  tls:
+    - hosts:
+        - backend.20.106.111.251.nip.io
+      secretName: backend-tls
   rules:
-    - http:
+    - host: backend.20.106.111.251.nip.io
+      http:
         paths:
           - path: /
             pathType: Prefix


### PR DESCRIPTION
## Summary
- Add `ClusterIssuer` (letsencrypt-prod) using HTTP-01/nginx solver at `infra/k8s/cluster-issuer.yaml`
- Update `infra/k8s/ingress.yaml`: set host `backend.20.106.111.251.nip.io`, TLS secret `backend-tls`, and `cert-manager.io/cluster-issuer` annotation
- Add `ALLOWED_ORIGINS` env var to backend deployment (from K8s secret) to configure CORS for the SWA hostname
- Fix CI smoke test: read backend URL from `spec.rules[0].host` instead of `status.loadBalancer.ingress[0].hostname` (nip.io hostname lives in spec, not status)
- Update `frontend/vue-app/.env.example` to HTTPS backend URL

## Required GitHub Actions variable (set before merge)
| Variable | Value |
|---|---|
| `ALLOWED_ORIGINS` | Your SWA hostname (e.g. `https://proud-sand-xxx.azurestaticapps.net`) |
| `VITE_API_BASE_URL` | `https://backend.20.106.111.251.nip.io` |

## Manual steps after merge
1. `kubectl apply -f infra/k8s/cluster-issuer.yaml` (one-time, or CI will apply on next backend deploy)
2. Wait for cert: `kubectl get certificate -n production` → Ready
3. Update `VITE_API_BASE_URL` GitHub Actions variable to `https://backend.20.106.111.251.nip.io` and redeploy frontend
4. Verify: `curl -sf https://backend.20.106.111.251.nip.io/health`

## Test plan
- [ ] `kubectl get clusterissuer letsencrypt-prod` shows Ready
- [ ] `kubectl get certificate -n production backend-tls` shows Ready
- [ ] `curl -sf https://backend.20.106.111.251.nip.io/health` returns `{"status":"ok"}`
- [ ] SWA frontend polls market data without mixed-content browser errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)