### PR TITLE
fix: update azure/arm-deploy to correct v2.0.0 SHA

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,7 +61,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Deploy Bicep template
-        uses: azure/arm-deploy@e792c9a34eb6a018b445eff5f1a6394f0c6e1e2d # v2.0.0
+        uses: azure/arm-deploy@a1361c2c2cd398621955b16ca32e01c65ea340f5 # v2.0.0
         with:
           scope: subscription
           region: ${{ env.AZURE_LOCATION }}
@@ -387,3 +387,4 @@ jobs:
           app_location: frontend/vue-app/dist
           output_location: ""
           skip_app_build: true
+


### PR DESCRIPTION
## Summary

- Fixes invalid SHA `e792c9a34eb6a018b445eff5f1a6394f0c6e1e2d` for `azure/arm-deploy@v2.0.0`
- Correct SHA is `a1361c2c2cd398621955b16ca32e01c65ea340f5` (verified via `gh api repos/Azure/arm-deploy/git/refs/tags/v2.0.0`)
- The bad SHA caused `deploy-infra` to fail at "Set up job" during action download, which in turn blocked `deploy-frontend` (frontend requires infra to succeed or be skipped)

## Root cause

When `workflow_dispatch` runs without a push base, `dorny/paths-filter` compares against an empty tree and reports all paths as changed — including `infra/bicep/**`. This triggered `deploy-infra`, which failed on the invalid SHA before any Azure calls were made.

## Test plan
- [ ] Merge this PR → `deploy-infra` gets past "Set up job"
- [ ] `deploy-frontend` runs and deploys built Vite assets to Azure Static Web Apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)